### PR TITLE
fix: remove important from block inline styles

### DIFF
--- a/src/CSP/WordPress/WordPressServiceProvider.php
+++ b/src/CSP/WordPress/WordPressServiceProvider.php
@@ -50,7 +50,7 @@ class WordPressServiceProvider extends ServiceProvider
                 if (empty($ruleElements[1])) {
                     continue;
                 }
-                $declarations[trim($ruleElements[0])] = trim($ruleElements[1]) . ' !important';
+                $declarations[trim($ruleElements[0])] = trim($ruleElements[1]);
             }
 
             if (! empty($declarations) && ! $shouldExcludeFromCss) {


### PR DESCRIPTION
Als de klant bijvoorbeeld bij een media-text instelt dat de kolommen `auto 33%` moet zijn, dan is er via de code geen enkele mogelijkheid dat wij dit kunnen overschrijven omdat de selector super specifiek is. Terwijl we in dit geval op mobiel willen forceren dat het 100% kolommen moeten zijn. Door de important er af te halen werkt de ingestelde css wel gewoon nog, maar kunnen we het op mobiel wel overschrijven.

Zie als voorbeeld: https://meedoen.hellendoorn.nl/informatie-inwoner/
<img width="1719" height="964" alt="image" src="https://github.com/user-attachments/assets/fd2533ff-1dcd-41a1-bb05-18eee8c1acfe" />
